### PR TITLE
fix binding of server.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -124,7 +124,7 @@ var Server = function(config, overrides) {
 
 	this._listen = this.listen;
 	this.listen = function(port) {
-		this._listen(port? port : config.port);
+		this._listen(port? port : config.port, config.host);
 		this.log('Server up listening at ' + config.host + ':' + config.port);
 			process.on('uncaughtException', function(e) {
 				self.log('[uncaughtException]: '+ e.message);


### PR DESCRIPTION
Fixed the bug about situation in which server.js listens all IPs and servernames which are free on host. Now it listens only <config.host>
